### PR TITLE
CD 커멘드 validation 코드 수정

### DIFF
--- a/tests/src/command_validate_test.cc
+++ b/tests/src/command_validate_test.cc
@@ -28,7 +28,7 @@ TEST(CDValidateTest, ValidateCDArgv3) {
     "cd"
   };
 
-  ASSERT_EQ(validate_cd_argv(argc, argv), 0);
+  ASSERT_EQ(validate_cd_argv(argc, argv), 1);
 }
 
 TEST(CDValidateTest, ValidateCDArgv4) {


### PR DESCRIPTION
`cd` 커맨드에 관련된 테스트 코드를 보면

```c
TEST(CDValidateTest, ValidateCDArgv3) {
  int argc = 1;
  char* argv[] = {
    "cd"
  };
 		 
  ASSERT_EQ(validate_cd_argv(argc, argv), 0);	
}
```

`cd` 커맨드가 **인자 없이 입력 됐을 때** validation error 가 나오게끔 테스트 코드가 작성돼있습니다.
하지만 각 OS에서는 `cd` 커맨드가 단독으로 입력됐을 때 아래와 같이 작동합니다.
 - `UNIX` :  `cd` 커맨드가 단독으로 입력됐을 때 홈 디렉토리로 이동합니다. (like `cd ~`)
 - `DOS & WINDOWS` : `cd` 커맨드가 단독으로 입력됐을 때 현재 디렉토리 구조의 모든 주소를 출력합니다. (like `pwd`)

이러한 이유로 테스트 코드에 관한 PR을 보냅니다-!